### PR TITLE
Add sleep before trying connection

### DIFF
--- a/custom_components/qbittorrent_alternative_speed/switch.py
+++ b/custom_components/qbittorrent_alternative_speed/switch.py
@@ -2,6 +2,7 @@ __version__ = "1.3.1"
 
 import logging
 import voluptuous as vol
+import time
 
 from qbittorrentapi import Client
 
@@ -35,6 +36,8 @@ def setup_platform(hass, config, add_devices, discovery_info=None):
     username = config.get(CONF_USERNAME)
     password = config.get(CONF_PASSWORD)
     name = config.get(CONF_NAME)
+
+    time.sleep(30)
 
     add_devices([qbittorrent_alternative_speed(
         host, username, password, name)], True)


### PR DESCRIPTION
I have been using this tool for a couple of months, but after having a lot of active torrents in the QBittorrent client, it made the client start up slower than Home Assistant. Since this "integration" doesn't have a proper init script, where the ConfigEntryNotReady exception could be thrown so that HA retries setup automatically, I chose a quick and dirty fix of adding a 30 second sleep before trying the connection. You can adjust this if you want.